### PR TITLE
fix: add @source directive to theme.css for Tailwind v4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,17 @@ npm install a2ui-react
 
 ## Setup
 
-Add the theme import and `@source` directive to your main CSS file:
+Add the theme import to your main CSS file:
 
 ```css
-/* Import the a2ui-react theme (includes Tailwind and all theme variables) */
+/* Import the a2ui-react theme (includes Tailwind, theme variables, and source scanning) */
 @import 'a2ui-react/theme.css';
-
-/* Tell Tailwind to scan the package for class usage */
-@source "../node_modules/a2ui-react/dist";
 ```
 
-Both lines are required:
-- `theme.css` provides Tailwind, shadcn/ui theme variables, and alert color tokens
-- `@source` ensures Tailwind includes the component classes (v4 doesn't scan node_modules by default)
+This single import provides:
+- Tailwind CSS base styles
+- shadcn/ui theme variables and alert color tokens
+- Automatic scanning of the package for Tailwind class usage (required for v4)
 
 ## Quick Start
 

--- a/packages/example/src/index.css
+++ b/packages/example/src/index.css
@@ -1,8 +1,5 @@
-/* Import the a2ui-react theme - use what we advertise */
+/* Import the a2ui-react theme (includes Tailwind, theme variables, and source scanning) */
 @import 'a2ui-react/theme.css';
-
-/* Tell Tailwind to scan the a2ui-react package for class usage */
-@source "../../shadcn/src/**/*.tsx";
 
 body {
   margin: 0;

--- a/packages/shadcn/src/theme.css
+++ b/packages/shadcn/src/theme.css
@@ -1,5 +1,9 @@
 @import 'tailwindcss';
 
+/* Tell Tailwind to scan this package's bundled code for class usage */
+/* This is required because Tailwind v4 ignores node_modules by default */
+@source ".";
+
 /* Dark mode variant for Tailwind v4 */
 @custom-variant dark (&:is(.dark *));
 


### PR DESCRIPTION
Tailwind v4 ignores node_modules by default when scanning for class usage. The previous setup required consumers to manually add @source directive, which often failed due to path resolution issues with different package managers and .gitignore conflicts.

By including @source "." in the package's theme.css, Tailwind automatically scans the dist folder when consumers import the theme. This simplifies setup to a single CSS import line.

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)